### PR TITLE
Add UNITY_SERVER to Mirror Network Provider

### DIFF
--- a/NetProviders/Mirror/MirrorFrame.cs
+++ b/NetProviders/Mirror/MirrorFrame.cs
@@ -1,6 +1,4 @@
-// THE USER MUST REMOVE #if MIRROR WHEN USING SERVER BUILDS
-
-#if MIRROR
+#if MIRROR || UNITY_SERVER
 using System;
 using Mirror;
 using UnityEngine;

--- a/NetProviders/Mirror/MirrorNetProvider.cs
+++ b/NetProviders/Mirror/MirrorNetProvider.cs
@@ -1,6 +1,4 @@
-// THE USER MUST REMOVE #if MIRROR WHEN USING SERVER BUILDS
-
-#if MIRROR
+#if MIRROR || UNITY_SERVER
 using System;
 using System.Collections.Generic;
 using MetaVoiceChat.Utils;


### PR DESCRIPTION
Makes it so you don't have to remove it on server builds.