### PR TITLE
Fix null reference in IsLocalPlayerDeafened and add error logging

### DIFF
--- a/NetProviders/FishNet/FishNetNetProvider.cs
+++ b/NetProviders/FishNet/FishNetNetProvider.cs
@@ -22,7 +22,7 @@ namespace MetaVoiceChat.NetProviders.FishNet
         public static IReadOnlyList<FishNetNetProvider> Instances => instances;
         #endregion
 
-        bool INetProvider.IsLocalPlayerDeafened => LocalPlayerInstance.MetaVc.isDeafened;
+        bool INetProvider.IsLocalPlayerDeafened => LocalPlayerInstance != null && LocalPlayerInstance.MetaVc.isDeafened;
 
         public MetaVc MetaVc { get; private set; }
 

--- a/NetProviders/Mirror/MirrorNetProvider.cs
+++ b/NetProviders/Mirror/MirrorNetProvider.cs
@@ -19,7 +19,7 @@ namespace MetaVoiceChat.NetProviders.Mirror
         public static IReadOnlyList<MirrorNetProvider> Instances => instances;
         #endregion
 
-        bool INetProvider.IsLocalPlayerDeafened => LocalPlayerInstance.MetaVc.isDeafened;
+        bool INetProvider.IsLocalPlayerDeafened => LocalPlayerInstance != null && LocalPlayerInstance.MetaVc.isDeafened;
 
         public MetaVc MetaVc { get; private set; }
 

--- a/NetProviders/Netick/NetickNetProvider.cs
+++ b/NetProviders/Netick/NetickNetProvider.cs
@@ -15,7 +15,7 @@ namespace MetaVoiceChat.NetProviders.Netick
         public static IReadOnlyList<NetickNetProvider> Instances => instances;
         #endregion
 
-        bool INetProvider.IsLocalPlayerDeafened => LocalPlayerInstance.MetaVc.isDeafened;
+        bool INetProvider.IsLocalPlayerDeafened => LocalPlayerInstance != null && LocalPlayerInstance.MetaVc.isDeafened;
 
         public MetaVc MetaVc { get; private set; }
 
@@ -78,16 +78,20 @@ namespace MetaVoiceChat.NetProviders.Netick
 
         void INetProvider.RelayFrame(int index, double timestamp, ReadOnlySpan<byte> data)
         {
+            if (VoiceDataTransmitter == null)
+            {
+                Debug.LogError("[MetaVoiceChat] MetaVoiceChatNetick component is missing from the Sandbox prefab.");
+                return;
+            }
+
             float additionalLatency = GetAdditionalLatency();
 
             if (Sandbox.IsServer)
             {
-                //send the data to all clients
                 VoiceDataTransmitter.SendServerVoiceToClients(index, timestamp, additionalLatency, data, playerID);
             }
             else
             {
-                //send the data from client to server
                 VoiceDataTransmitter.SendVoiceDataToServer(index, timestamp, additionalLatency, data);
             }
         }

--- a/NetProviders/Netick/NetickNetProvider.cs
+++ b/NetProviders/Netick/NetickNetProvider.cs
@@ -88,10 +88,12 @@ namespace MetaVoiceChat.NetProviders.Netick
 
             if (Sandbox.IsServer)
             {
+                //send the data to all clients
                 VoiceDataTransmitter.SendServerVoiceToClients(index, timestamp, additionalLatency, data, playerID);
             }
             else
             {
+                //send the data from client to server
                 VoiceDataTransmitter.SendVoiceDataToServer(index, timestamp, additionalLatency, data);
             }
         }


### PR DESCRIPTION
- Mirror, FishNet, Netick: added null guard on LocalPlayerInstance in IsLocalPlayerDeafened to match NGO provider behavior
- Netick: added null guard on VoiceDataTransmitter in RelayFrame since it's only assigned server-side, clients would crash silently without it